### PR TITLE
fix: Use new variable names for paths

### DIFF
--- a/adapter/CONFIG_SITE.local.in
+++ b/adapter/CONFIG_SITE.local.in
@@ -22,8 +22,8 @@
 # CHIMERATK_INCLUDE and CHIMERATK_LIB only have to be defined if they do not
 # match $(CHIMERATK_DIR)/include and $(CHIMERATK_DIR)/lib
 
-CHIMERATK_INCLUDE = ${ChimeraTK-ControlSystemAdapter_INCLUDE_DIR}
-CHIMERATK_LIB = ${ChimeraTK-ControlSystemAdapter_LIBRARY_DIR}
+CHIMERATK_INCLUDE = ${ChimeraTK-ControlSystemAdapter_INCLUDE_DIRS}
+CHIMERATK_LIB = ${ChimeraTK-ControlSystemAdapter_LIBRARY_DIRS}
 
 # If the compiler is not expecting C++ 11 code by default, it has to be told
 # to do so.

--- a/ioc/CONFIG_SITE.in
+++ b/ioc/CONFIG_SITE.in
@@ -35,7 +35,7 @@ CHECK_RELEASE = YES
 #HOST_OPT = NO
 #CROSS_OPT = NO
 
-USR_LDFLAGS += -L${ChimeraTK-ControlSystemAdapter_LIBRARY_DIR}
+USR_LDFLAGS += -L${ChimeraTK-ControlSystemAdapter_LIBRARY_DIRS}
 
 # These allow developers to override the CONFIG_SITE variable
 # settings without having to modify the configure/CONFIG_SITE


### PR DESCRIPTION
Fixes linking error against ControlSystemAdapter
